### PR TITLE
13-add-audit-trail

### DIFF
--- a/app/Http/Controllers/AuditController.php
+++ b/app/Http/Controllers/AuditController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class AuditController extends Controller
+{
+    //
+}

--- a/app/Models/Audit.php
+++ b/app/Models/Audit.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Audit extends Model
+{
+    use HasFactory;
+    protected $fillable = ['action_type', 'user_id', 'affected_product_id'];
+}

--- a/app/Observers/ProductObserver.php
+++ b/app/Observers/ProductObserver.php
@@ -14,8 +14,7 @@ class ProductObserver
     {
         Audit::create([
             // 'user_id'=>1, When seeding product creation does not have a user id - thus set user_id to one when seeding then back to user id thereafter.
-
-            'user_id'=>auth()->id(),
+            'user_id'=>auth()->check()?auth()->id() : 1,
             'action_type'=>'created',
             'affected_product_id'=>$product->id,
         ]);
@@ -27,7 +26,7 @@ class ProductObserver
     public function updated(Product $product): void
     {
         Audit::create([
-            'user_id'=>auth()->id(),
+            'user_id'=>auth()->check()?auth()->id() : 1,
             'action_type'=>'updated',
             'affected_product_id'=>$product->id,
         ]);
@@ -39,7 +38,7 @@ class ProductObserver
     public function deleted(Product $product): void
     {
         Audit::create([
-            'user_id'=>auth()->id(),
+            'user_id'=>auth()->check()?auth()->id() : 1,
             'action_type'=>'deleted',
             'affected_product_id'=>$product->id,
         ]);

--- a/app/Observers/ProductObserver.php
+++ b/app/Observers/ProductObserver.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Product;
+use App\Models\Audit;
+
+class ProductObserver
+{
+    /**
+     * Handle the Product "created" event.
+     */
+    public function created(Product $product): void
+    {
+        Audit::create([
+            // 'user_id'=>1, When seeding product creation does not have a user id - thus set user_id to one when seeding then back to user id thereafter.
+
+            'user_id'=>auth()->id(),
+            'action_type'=>'created',
+            'affected_product_id'=>$product->id,
+        ]);
+    }
+
+    /**
+     * Handle the Product "updated" event.
+     */
+    public function updated(Product $product): void
+    {
+        Audit::create([
+            'user_id'=>auth()->id(),
+            'action_type'=>'updated',
+            'affected_product_id'=>$product->id,
+        ]);
+    }
+
+    /**
+     * Handle the Product "deleted" event.
+     */
+    public function deleted(Product $product): void
+    {
+        Audit::create([
+            'user_id'=>auth()->id(),
+            'action_type'=>'deleted',
+            'affected_product_id'=>$product->id,
+        ]);
+    }
+
+    /**
+     * Handle the Product "restored" event.
+     */
+    public function restored(Product $product): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Product "force deleted" event.
+     */
+    public function forceDeleted(Product $product): void
+    {
+        //
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\Product;
+use App\Observers\ProductObserver;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +21,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Product::observe(ProductObserver::class);
     }
 }

--- a/database/migrations/2023_12_11_113826_create_audits_table.php
+++ b/database/migrations/2023_12_11_113826_create_audits_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('audits', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(User::class);
+            $table->string('action_type');
+            $table->foreignIdFor(Product::class, 'affected_product_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('audits');
+    }
+};


### PR DESCRIPTION
- added a migration to add audits table 
- created audit model 
- created a product observer to fire every time product create, updated or deleted. 
- registered the observer 
- may need a better way to handle the db seeding as was error caused by observer creating a new audit entry every time product created, but there was no user id to add as the foreign key. 